### PR TITLE
Updated openHAB for Garmin URL

### DIFF
--- a/awesome-generator/awesome.toml
+++ b/awesome-generator/awesome.toml
@@ -339,7 +339,7 @@
 "https://github.com/SylvainGa/Garmin-WeeWX" = {}
 "https://github.com/SylvainGa/Tesla-Link" = {}
 "https://github.com/TheNinth7/evccg" = {}
-"https://github.com/TheNinth7/ohg" = {}
+"https://github.com/openhab/openhab-garmin" = {}
 "https://github.com/TimZander/slope-widget" = {}
 "https://github.com/Vertumnus/garmin-ioBrokerVis" = {}
 "https://github.com/YoungChulDK/GarminCryptoPrices" = {}

--- a/awesome-generator/awesome.toml
+++ b/awesome-generator/awesome.toml
@@ -334,7 +334,6 @@
 "https://github.com/Likenttt/DogecoinToTheMoon" = {}
 "https://github.com/Marios007/WoP" = { description = "Pregnancy Widget for Garmin Watches" }
 "https://github.com/PlanetTeamSpeakk/UC-Widget" = {}
-"https://github.com/openhab/openhab-garmin" = {}
 "https://github.com/SylvainGa/Calculator" = {}
 "https://github.com/SylvainGa/Flashlight" = {}
 "https://github.com/SylvainGa/Garmin-WeeWX" = {}
@@ -404,6 +403,7 @@
 "https://github.com/mriscott/GarminRings" = {}
 "https://github.com/natabat/FertiliQ" = {}
 "https://github.com/okdar/lostandfound" = {}
+"https://github.com/openhab/openhab-garmin" = {}
 "https://github.com/pedlarstudios/WordOfTheDay" = {}
 "https://github.com/pyrob2142/FastingWidget" = {}
 "https://github.com/serhuz/CryptoMarket" = {}

--- a/awesome-generator/awesome.toml
+++ b/awesome-generator/awesome.toml
@@ -334,12 +334,12 @@
 "https://github.com/Likenttt/DogecoinToTheMoon" = {}
 "https://github.com/Marios007/WoP" = { description = "Pregnancy Widget for Garmin Watches" }
 "https://github.com/PlanetTeamSpeakk/UC-Widget" = {}
+"https://github.com/openhab/openhab-garmin" = {}
 "https://github.com/SylvainGa/Calculator" = {}
 "https://github.com/SylvainGa/Flashlight" = {}
 "https://github.com/SylvainGa/Garmin-WeeWX" = {}
 "https://github.com/SylvainGa/Tesla-Link" = {}
 "https://github.com/TheNinth7/evccg" = {}
-"https://github.com/openhab/openhab-garmin" = {}
 "https://github.com/TimZander/slope-widget" = {}
 "https://github.com/Vertumnus/garmin-ioBrokerVis" = {}
 "https://github.com/YoungChulDK/GarminCryptoPrices" = {}


### PR DESCRIPTION
The app is now an official part of openHAB and is maintained under the openHAB Foundation's GitHub account.