### PR TITLE
Add garmin-ai-notifier to Tools

### DIFF
--- a/awesome-generator/awesome.toml
+++ b/awesome-generator/awesome.toml
@@ -682,6 +682,7 @@
 "https://github.com/Nick2bad4u/FitFileViewer" = {}
 "https://github.com/RobertWojtowicz/export2garmin" = {}
 "https://github.com/arpanghosh8453/garmin-grafana" = {}
+"https://github.com/deep0410/garmin-ai-notifier" = { description = "Free automated daily AI brief on Garmin Connect data: SQLite history, full-history stats, Gemini insight, phone push via ntfy/Telegram. GitHub Actions." }
 "https://github.com/blackdogit/connectiq-monkeyc" = {}
 "https://github.com/blackshadev/garmin-connectiq-release-action" = {}
 "https://github.com/bombsimon/garmin-screenshot" = {}


### PR DESCRIPTION
Adds [garmin-ai-notifier](https://github.com/deep0410/garmin-ai-notifier) to the **Tools** section via `awesome.toml`.

Python pipeline using `garminconnect`: daily Garmin Connect pull → SQLite → statistical digest → Gemini brief → ntfy/Telegram/email. Scheduled on GitHub Actions.

Complements tools like garmin-grafana (dashboards) with a daily coached notification focused on full-history context.

Made with [Cursor](https://cursor.com)