### PR TITLE
Add garmin-health-data to Tools

### DIFF
--- a/awesome-generator/awesome.toml
+++ b/awesome-generator/awesome.toml
@@ -697,6 +697,7 @@
 "https://github.com/cyberang3l/GarminSettingsFileParser" = {}
 "https://github.com/cyberang3l/garmin-linux-development-environment" = {}
 "https://github.com/cyberang3l/vim-monkey-c" = {}
+"https://github.com/diegoscarabelli/garmin-health-data" = {}
 "https://github.com/etweisberg/garmin-connect-mcp" = {}
 "https://github.com/flocsy/GarminSportsDev" = {}
 "https://github.com/flocsy/garmin-dev-tools" = {}


### PR DESCRIPTION
Adds [garmin-health-data](https://github.com/diegoscarabelli/garmin-health-data), a Python CLI that downloads a full Garmin Connect account (activities and FIT files, sleep, HRV, body composition, and more) to local files and loads them into a documented SQLite database for analysis. It fits in the Tools section alongside GarminDB.

Per the contribution notes, I added the entry to `awesome-generator/awesome.toml` (not the generated `README.md`), placed alphabetically within `[tools]`. Since the repository already has a GitHub description, I left the value empty (`= {}`) so the generator can fetch the description, stars, and last activity.

Thanks for maintaining this list!
